### PR TITLE
grpc-ring compile fix using rev commit

### DIFF
--- a/Chapter06/grpc-ring/Cargo.toml
+++ b/Chapter06/grpc-ring/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 [dependencies]
 env_logger = "0.6"
 failure = "0.1"
-grpc = { git = "https://github.com/stepancheg/grpc-rust" }
+grpc = { git = "https://github.com/stepancheg/grpc-rust", rev="07bb7a50f9c6a816fff65629f02be432d619ff4f" }
 log = "0.4"
 protobuf = "2.2"
 
 [build-dependencies]
-protoc-rust-grpc = { git = "https://github.com/stepancheg/grpc-rust" }
+protoc-rust-grpc = { git = "https://github.com/stepancheg/grpc-rust", rev="07bb7a50f9c6a816fff65629f02be432d619ff4f" }
 
 [[bin]]
 name = "grpc-ring"


### PR DESCRIPTION
Fixes #15  setting the grpc-rust git repository to a compatible commit in Cargo.toml